### PR TITLE
feat: implement landmark retrieval api and service

### DIFF
--- a/src/main/kotlin/com/snuxi/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/snuxi/config/SecurityConfig.kt
@@ -34,6 +34,8 @@ class SecurityConfig(
                     "/",
                     "/login",
                     "/error",
+                    "/maps/landmarks",
+                    "/rooms/search",
                     "/oauth2/**",
                     "/login/oauth2/**",
                     "/favicon.ico",

--- a/src/main/kotlin/com/snuxi/pot/controller/LandmarkController.kt
+++ b/src/main/kotlin/com/snuxi/pot/controller/LandmarkController.kt
@@ -1,0 +1,20 @@
+package com.snuxi.pot.controller
+
+import com.snuxi.pot.dto.response.LandmarkListResponse
+import com.snuxi.pot.dto.core.LandmarkDto
+import com.snuxi.pot.repository.LandmarkRepository
+import com.snuxi.pot.service.LandmarkService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/maps")
+class LandmarkController(
+    private val landmarkService: LandmarkService // 주입 변경
+) {
+    @GetMapping("/landmarks")
+    fun getLandmarks(): LandmarkListResponse {
+        return LandmarkListResponse(landmarkService.getAllLandmarks())
+    }
+}

--- a/src/main/kotlin/com/snuxi/pot/dto/core/LandmarkDto.kt
+++ b/src/main/kotlin/com/snuxi/pot/dto/core/LandmarkDto.kt
@@ -1,0 +1,28 @@
+package com.snuxi.pot.dto.core
+
+import com.snuxi.pot.model.Landmark
+import java.math.BigDecimal
+
+data class LandmarkDto(
+    val id: Long,
+    val name: String,
+    val latitude: BigDecimal,
+    val longitude: BigDecimal
+) {
+    companion object {
+        fun from(landmark: Landmark) = LandmarkDto(
+            id = landmark.id!!,
+            name = landmark.landmarkName,
+            latitude = landmark.latitude,
+            longitude = landmark.longitude
+        )
+
+        fun generateKakaoLink(origin: LandmarkDto, dest: LandmarkDto): String {
+            return "https://t.kakao.com/launch?type=taxi" +
+                    "&origin_lat=${origin.latitude}" +
+                    "&origin_lng=${origin.longitude}" +
+                    "&dest_lat=${dest.latitude}" +
+                    "&dest_lng=${dest.longitude}"
+        }
+    }
+}

--- a/src/main/kotlin/com/snuxi/pot/dto/response/LandmarkListResponse.kt
+++ b/src/main/kotlin/com/snuxi/pot/dto/response/LandmarkListResponse.kt
@@ -1,0 +1,7 @@
+package com.snuxi.pot.dto.response
+
+import com.snuxi.pot.dto.core.LandmarkDto
+
+data class LandmarkListResponse(
+    val landmarks: List<LandmarkDto>
+)

--- a/src/main/kotlin/com/snuxi/pot/model/Landmark.kt
+++ b/src/main/kotlin/com/snuxi/pot/model/Landmark.kt
@@ -1,0 +1,21 @@
+package com.snuxi.pot.model
+
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "landmarks")
+class Landmark (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "landmark_name", nullable = false)
+    val landmarkName: String,
+
+    @Column(nullable = false, precision = 7, scale = 5)
+    val latitude: BigDecimal,
+
+    @Column(nullable = false, precision = 8, scale = 5)
+    val longitude: BigDecimal
+)

--- a/src/main/kotlin/com/snuxi/pot/repository/LandmarkRepository.kt
+++ b/src/main/kotlin/com/snuxi/pot/repository/LandmarkRepository.kt
@@ -1,0 +1,8 @@
+package com.snuxi.pot.repository
+
+import com.snuxi.pot.model.Landmark
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface LandmarkRepository : JpaRepository<Landmark, Long>

--- a/src/main/kotlin/com/snuxi/pot/service/LandmarkService.kt
+++ b/src/main/kotlin/com/snuxi/pot/service/LandmarkService.kt
@@ -1,0 +1,16 @@
+package com.snuxi.pot.service
+
+import com.snuxi.pot.dto.core.LandmarkDto
+import com.snuxi.pot.repository.LandmarkRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LandmarkService(
+    private val landmarkRepository: LandmarkRepository
+) {
+    @Transactional(readOnly = true)
+    fun getAllLandmarks(): List<LandmarkDto> {
+        return landmarkRepository.findAll().map { LandmarkDto.from(it) }
+    }
+}


### PR DESCRIPTION
1. 랜드마크 API (GET /maps/landmarks) 구현

2.  카카오택시 딥링크 유틸리티
LandmarkDto에 좌표를 조합해 카카오택시 앱 실행하는 딥링크 생성 로직(generateKakaoLink)을 포함했습니다. 

3. 보안 설정 
/maps/landmarks 및 /rooms/search 경로를 permitAll() 목록에 추가했습니다. 인증 없이 접근 가능하도록 했습니