### PR TITLE
feat/약관 철회 시 탈퇴 기능

### DIFF
--- a/src/main/kotlin/com/snuxi/notification/repository/UserDeviceRepository.kt
+++ b/src/main/kotlin/com/snuxi/notification/repository/UserDeviceRepository.kt
@@ -14,4 +14,5 @@ interface UserDeviceRepository : JpaRepository<UserDevice, Long> {
 
     // 방 참여자 여러 명에게 한꺼번에 보낼 때 사용
     fun findAllByUserIdIn(userIds: List<Long>): List<UserDevice>
+    fun deleteAllByUserId(userId: Long)
 }

--- a/src/main/kotlin/com/snuxi/participant/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/snuxi/participant/repository/ParticipantRepository.kt
@@ -51,4 +51,6 @@ interface ParticipantRepository : JpaRepository<Participants, Long>{
         @Param("potId") potId: Long,
         @Param("messageId") messageId: Long
     )
+
+    fun deleteAllByUserId(userId: Long)
 }

--- a/src/main/kotlin/com/snuxi/pot/repository/PotRepository.kt
+++ b/src/main/kotlin/com/snuxi/pot/repository/PotRepository.kt
@@ -119,5 +119,5 @@ interface PotRepository : JpaRepository<Pots, Long> {
 
     fun countByStatus(status: PotStatus): Long
     fun countByCreatedAtBetween(start: Instant, end: Instant): Long
-
+    fun deleteAllByOwnerId(userId: Long)
 }

--- a/src/main/kotlin/com/snuxi/terms/repository/UserTermsAgreementRepository.kt
+++ b/src/main/kotlin/com/snuxi/terms/repository/UserTermsAgreementRepository.kt
@@ -13,4 +13,6 @@ interface UserTermsAgreementRepository : JpaRepository<UserTermsAgreement, Long>
         userId: Long,
         termsVersion: BigDecimal
     ): Boolean
+
+    fun deleteAllByUserId(userId: Long)
 }

--- a/src/main/kotlin/com/snuxi/terms/service/UserTermsAgreementService.kt
+++ b/src/main/kotlin/com/snuxi/terms/service/UserTermsAgreementService.kt
@@ -2,13 +2,16 @@ package com.snuxi.terms.service
 
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
+import jakarta.transaction.Transactional
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.util.Date
+import com.snuxi.terms.repository.UserTermsAgreementRepository
 
 @Service
 class UserTermsAgreementService (
+    private val userTermsAgreementRepository: UserTermsAgreementRepository,
     @Value("\${app.terms-jwt.secret}")
     private val secret: String,
     @Value("\${app.terms-jwt.ttl-minutes}")
@@ -61,6 +64,11 @@ class UserTermsAgreementService (
         } catch (e: Exception) {
             null
         }
+    }
+    @Transactional
+    fun revokeAllAgreements(userId: Long) {
+        // 해당 유저의 모든 약관 동의 내역 삭제
+        userTermsAgreementRepository.deleteAllByUserId(userId)
     }
 }
 

--- a/src/main/kotlin/com/snuxi/user/service/UserService.kt
+++ b/src/main/kotlin/com/snuxi/user/service/UserService.kt
@@ -5,11 +5,17 @@ import com.snuxi.user.dto.UserResponse
 import com.snuxi.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import com.snuxi.participant.repository.ParticipantRepository
+import com.snuxi.notification.repository.UserDeviceRepository
+import com.snuxi.pot.repository.PotRepository
 
 @Service
 @Transactional
 class UserService(
-    val userRepository: UserRepository
+    val userRepository: UserRepository,
+    private val participantRepository: ParticipantRepository,
+    private val userDeviceRepository: UserDeviceRepository,
+    private val potRepository: PotRepository
 ) {
     fun getProfile(email: String): UserResponse {
         val user = userRepository.findByEmail(email)
@@ -29,5 +35,17 @@ class UserService(
         val user = userRepository.findById(userId)
             .orElseThrow { UserNotFoundException() }
         user.notificationEnabled = enabled
+    }
+    @Transactional
+    fun withdraw(userId: Long) {
+        val user = userRepository.findById(userId)
+            .orElseThrow { UserNotFoundException() }
+        // 참여 중인 팟 있다면 탈퇴
+        potRepository.deleteAllByOwnerId(userId)
+        participantRepository.deleteAllByUserId(userId)
+        // 등록된 기기 정보 삭제(알림)
+        userDeviceRepository.deleteAllByUserId(userId)
+        // 유저 삭제
+        userRepository.delete(user)
     }
 }


### PR DESCRIPTION
탈퇴 시 안전하게 기존 데이터 삭제하는 부분 추가로 보충이 필요한데, 일단 동의 안하면 서비스 이용을 못한다는 가정 하에 기존 데이터 삭제는 대강 해뒀습니다. 