### PR TITLE
fix: throw FareNotFoundException when fare data missing

### DIFF
--- a/src/main/kotlin/com/snuxi/pot/PotException.kt
+++ b/src/main/kotlin/com/snuxi/pot/PotException.kt
@@ -115,3 +115,10 @@ class PastDepartureTimeException :
         httpStatusCode = HttpStatus.BAD_REQUEST,
         msg = "출발 시간은 현재 시각 이후여야 합니다."
     )
+
+class FareNotFoundException :
+    PotException(
+        errorCode = 1010003404,
+        httpStatusCode = HttpStatus.NOT_FOUND,
+        msg = "해당 경로의 예상 요금 정보를 찾을 수 없습니다."
+    )

--- a/src/main/kotlin/com/snuxi/pot/service/PotService.kt
+++ b/src/main/kotlin/com/snuxi/pot/service/PotService.kt
@@ -7,6 +7,7 @@ import com.snuxi.participant.entity.Participants
 import com.snuxi.participant.repository.ParticipantRepository
 import com.snuxi.pot.AlreadyJoinedThisPotException
 import com.snuxi.pot.CannotKickSelfException
+import com.snuxi.pot.FareNotFoundException
 import com.snuxi.pot.InvalidCountException
 import com.snuxi.pot.KakaoCallStatus
 import com.snuxi.pot.KakaoDeepLinkNotOwnerException
@@ -72,7 +73,7 @@ class PotService (
         val baseFare = landmarkPairFareRepository
             .findByDepartureIdAndDestinationId(departureId, destinationId)
             ?.estimatedFare
-            ?: 0
+            ?: throw FareNotFoundException()
         val estimatedFee = applyTimeSurcharge(baseFare, departureTime)
 
         val save = potRepository.save(


### PR DESCRIPTION
## 변경사항
- `landmark_pair_fares`에 해당 경로 데이터가 없을 때 `estimatedFee=0`으로 조용히 넘어가던 버그 수정
- `?: 0` → `?: throw FareNotFoundException()`
- `FareNotFoundException` (404) 추가

## 원인
- landmark 16(서울대입구역 2번 출구) 추가 후 fare 데이터 미삽입
- `applyTimeSurcharge(0)`이 `return 0`하면서 금액 0원 표시

## DB 수정 (이미 적용됨)
- landmark 16 좌표 수정 (정확한 2번출구 위치)
- landmark 16 ↔ 나머지 15개 fare 데이터 30건 삽입
- pot 126 `estimated_fee` 0 → 8120 (심야할증 반영) 수정