### PR TITLE
fix: add missing qr_scans migration for QR redirect tracking

### DIFF
--- a/src/main/resources/db/migration/V21__create_table_qr_scans.sql
+++ b/src/main/resources/db/migration/V21__create_table_qr_scans.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS qr_scans (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    code VARCHAR(32) NOT NULL,
+    scanned_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    user_agent VARCHAR(512),
+    ip VARCHAR(45),
+    referer VARCHAR(512),
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_qr_scans_code ON qr_scans(code);
+CREATE INDEX idx_qr_scans_scanned_at ON qr_scans(scanned_at);


### PR DESCRIPTION
## Summary
- add Flyway migration V21 to create `qr_scans` table
- add indexes on `code` and `scanned_at` for aggregation/query performance

## Why
`/go/{code}` persists scans via `QrScanRepository`, but table creation migration was missing in #118. This caused runtime 500 on redirect endpoint.

## Verification
- confirmed `QrRedirectController` writes to `qr_scans`
- confirmed no existing migration creates `qr_scans`
- migration is idempotent with `IF NOT EXISTS`
